### PR TITLE
Implement connection upgrade to WebSocket

### DIFF
--- a/openeo.js
+++ b/openeo.js
@@ -229,7 +229,16 @@ class JobAPI {
 	}
 	
 	subscribe() {
-		throw new Error('Not implemented');
+		console.warn('Subscriptions are not (fully) implemented (yet)');
+		// This way we would have to do everything manually:
+		// return OpenEO.HTTP.post('/jobs/' + encodeURIComponent(this.job_id) + '/subscriptions');
+		// This takes care of the upgrading automatically:
+		const socket = new WebSocket(OpenEO.API.baseUrl.replace('http', 'ws') + '/jobs/' + encodeURIComponent(this.job_id) + '/subscriptions');
+		// However, there's no way (at least I haven't found one) to do this with a POST instead of a GET... (although doing so would be valid according to the specs!)
+		socket.addEventListener('open', function (event) {
+			console.log('WebSocket connection has been opened successfully.');
+		});
+		return socket;
 	}
 	
 	queue() {
@@ -413,6 +422,10 @@ class Capabilities {
 	
 	downloadJob() {
 		return this.capable('/jobs/{job_id}/download');
+	}
+
+	subscribeToJob() {
+		return this.capable('/jobs/{job_id}/subscriptions', 'post');
 	}
 	
 	createService() {


### PR DESCRIPTION
Using the WebSocket constructor is by far the simplest method to do this, but it doesn't provide a way to change the request method from GET to POST (one can only specify the URL and a list of subprotocols, see https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket). Regardless, I used this handy automatic way for now.