### PR TITLE
Run monitorFn always on start #26

### DIFF
--- a/src/baseentity.js
+++ b/src/baseentity.js
@@ -17,6 +17,7 @@ class BaseEntity {
 		this.connection = connection;
 		this.apiToClientNames = {};
 		this.clientToApiNames = {};
+		this.lastRefreshTime = 0;
 		this.extra = {};
 		for(let i in properties) {
 			let backend, client;
@@ -59,7 +60,17 @@ class BaseEntity {
 				this[this.apiToClientNames[name]] = metadata[name];
 			}
 		}
+		this.lastRefreshTime = Date.now();
 		return this;
+	}
+
+	/**
+	 * Returns the age of the data in seconds.
+	 * 
+	 * @returns {integer}
+	 */
+	getDataAge() {
+		return (Date.now() - this.lastRefreshTime) / 1000;
 	}
 
 	/**

--- a/src/job.js
+++ b/src/job.js
@@ -95,8 +95,8 @@ class Job extends BaseEntity {
 	 * Checks for status changes and new log entries every x seconds.
 	 * 
 	 * On every status change observed or on new log entries (if supported by the back-end),
-	 * the callback is executed.
-	 * The callback receives the job (this object) and the logs (array) passed.
+	 * the callback is executed. It is also executed once at the beginning.
+	 * The callback receives the updated job (this object) and the logs (array) passed.
 	 * 
 	 * The monitoring stops once the job has finished, was canceled or errored out.
 	 * 
@@ -118,7 +118,7 @@ class Job extends BaseEntity {
 			throw new Error('Monitoring Jobs not supported by the back-end.');
 		}
 
-		let lastStatus = this.status;
+		let lastStatus = null;
 		let intervalId = null;
 		let logIterator = null;
 		if (capabilities.hasFeature('debugJob')) {
@@ -135,7 +135,8 @@ class Job extends BaseEntity {
 				stopFn();
 			}
 		};
-		intervalId = setTimeout(monitorFn, interval * 1000);
+		setTimeout(monitorFn, 0);
+		intervalId = setInterval(monitorFn, interval * 1000);
 		let stopFn = () => {
 			if (intervalId) {
 				clearInterval(intervalId);

--- a/src/service.js
+++ b/src/service.js
@@ -81,8 +81,8 @@ class Service extends BaseEntity {
 	 * Checks for new log entries every x seconds.
 	 * 
 	 * On every status change (enabled/disabled) observed or on new log entries (if supported by the back-end),
-	 * the callback is executed.
-	 * The callback receives the service (this object) and the logs (array) passed.
+	 * the callback is executed. It is also executed once at the beginning.
+	 * The callback receives the updated service (this object) and the logs (array) passed.
 	 * 
 	 * Returns a function that can be called to stop monitoring the service manually.
 	 * The monitoring must be stopped manually, otherwise it runs forever.
@@ -103,7 +103,7 @@ class Service extends BaseEntity {
 			throw new Error('Monitoring Services not supported by the back-end.');
 		}
 
-		let wasEnabled = this.enabled;
+		let wasEnabled = null;
 		let intervalId = null;
 		let logIterator = null;
 		if (capabilities.hasFeature('debugService')) {
@@ -117,7 +117,8 @@ class Service extends BaseEntity {
 			}
 			wasEnabled = this.enabled;
 		};
-		intervalId = setTimeout(monitorFn, interval * 1000);
+		setTimeout(monitorFn, 0);
+		intervalId = setInterval(monitorFn, interval * 1000);
 		let stopFn = () => {
 			if (intervalId) {
 				clearInterval(intervalId);


### PR DESCRIPTION
Fix bug: use setInterval instead of setTimeout

Call callback once always at the start to pass the job info also if there are no new jobs.

Issue: #26