### PR TITLE
OIDC extensibility and set token

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -221,7 +221,7 @@ class Connection {
 	 * `id`, `issuer`, `title` etc.
 	 * 
 	 * The function must return an instance of AuthProvider or any derived class.
-	 * May return `null` is the instance can't be created.
+	 * May return `null` if the instance can't be created.
 	 *
 	 * @callback oidcProviderFactoryFunction
 	 * @param {object} providerInfo


### PR DESCRIPTION
- Make OIDC more extensible (allow replacing the library with AppAuth-JS or so)
- Allow to set token information directly (not recommended, but anyway)

The build is failing due to GEE changes, is not related to this PR.