### PR TITLE
v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.0] - 2020-11-18
+## [1.0.1] - 2020-11-19
+
+### Fixed
+- Don't set unnecessary `withCredentials` option on HTTP requests for better CORS support. [openeo-api#41](https://github.com/Open-EO/openeo-api/issues/41)
+
+## [1.0.0] - 2020-11-17
 
 ### Fixed
 - Throw better error message in case openeo-identifier can't be retrieved. [#37](https://github.com/Open-EO/openeo-js-client/issues/37)
@@ -16,4 +21,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 All prior releases have been documented in the [GitHub Releases](https://github.com/Open-EO/openeo-js-client/releases).
 
 [Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...HEAD
+[1.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0-rc.5...v1.0.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 JavaScript/TypeScript client for the openEO API.
 
-* [Documentation](https://open-eo.github.io/openeo-js-client/1.0.0/).
+* [Documentation](https://open-eo.github.io/openeo-js-client/1.0.1/).
 
-The version of this client is **1.0.0** and supports **openEO API versions 1.0.x**.
+The version of this client is **1.0.1** and supports **openEO API versions 1.0.x**.
 Legacy versions are available as releases.
 See the [CHANGELOG](CHANGELOG.md) for recent changes.
 
@@ -53,7 +53,7 @@ In Node.js:
 In Typescript:
 * [Basic Discovery (promises)](examples/typescript/discovery.ts)
 
-More information can be found in the [documentation](https://open-eo.github.io/openeo-js-client/1.0.0/).
+More information can be found in the [documentation](https://open-eo.github.io/openeo-js-client/1.0.1/).
 
 ## Development
 

--- a/examples/node/package.json
+++ b/examples/node/package.json
@@ -22,7 +22,7 @@
   },
   "main": "discovery.js",
   "dependencies": {
-    "@openeo/js-client": "^1.0.0"
+    "@openeo/js-client": "^1.0.1"
   },
   "scripts": {
     "start": "node discovery.js"

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -22,7 +22,7 @@
   },
   "main": "discovery.ts",
   "dependencies": {
-    "@openeo/js-client": "^1.0.0",
+    "@openeo/js-client": "^1.0.1",
     "typescript": "^4.0.5"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openeo/js-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "openEO Consortium",
   "contributors": [
     {

--- a/src/connection.js
+++ b/src/connection.js
@@ -821,7 +821,7 @@ class Connection {
 			method: 'get',
 			responseType: Environment.getResponseType(),
 			url: url,
-			withCredentials: authorize
+			authorization: authorize
 		});
 		return result.data;
 	}
@@ -846,8 +846,7 @@ class Connection {
 	 */
 	async _send(options) {
 		options.baseURL = this.baseUrl;
-		if (this.isAuthenticated() && (typeof options.withCredentials === 'undefined' || options.withCredentials === true)) {
-			options.withCredentials = true;
+		if (this.isAuthenticated() && (typeof options.authorization === 'undefined' || options.authorization === true)) {
 			if (!options.headers) {
 				options.headers = {};
 			}

--- a/src/openeo.js
+++ b/src/openeo.js
@@ -104,7 +104,7 @@ class OpenEO {
 	 * @returns {string} Version number (according to SemVer).
 	 */
 	static clientVersion() {
-		return "1.0.0";
+		return "1.0.1";
 	}
 
 }


### PR DESCRIPTION
## [1.0.1] - 2020-11-19

### Fixed
- Don't set unnecessary `withCredentials` option on HTTP requests for better CORS support. [openeo-api#41](https://github.com/Open-EO/openeo-api/issues/41)

See the comment below for an explanation in the code.