### PR TITLE
Set MAX_API_VERSION to allow patch releases

### DIFF
--- a/src/openeo.js
+++ b/src/openeo.js
@@ -26,7 +26,7 @@ const Parameter = require('./builder/parameter');
 const Formula = require('./builder/formula');
 
 const MIN_API_VERSION = '1.0.0-rc.2';
-const MAX_API_VERSION = '1';
+const MAX_API_VERSION = '1.0.x';
 
 /**
  * Main class to start with openEO. Allows to connect to a server.

--- a/src/openeo.js
+++ b/src/openeo.js
@@ -26,7 +26,7 @@ const Parameter = require('./builder/parameter');
 const Formula = require('./builder/formula');
 
 const MIN_API_VERSION = '1.0.0-rc.2';
-const MAX_API_VERSION = '1.0.x';
+const MAX_API_VERSION = '1.x.x';
 
 /**
  * Main class to start with openEO. Allows to connect to a server.


### PR DESCRIPTION
Previously a server that responded with `"api_version": "1.0.1"` would be considered to be not supported, as

```js
Versions.compare('1.0.1', '1', "<=")
```

… correctly evaluates to `false`. Changing the maximum supprted API version to allow patch releases fixes this.

This is also in concordance with the supported version range of the README.


The testfailure happens for me locally with or without this patch being applied.

I wasn't sure whether to point this PR towards the `master` or `development` branch.

Please review.