### PR TITLE
Implicit array_create/constant for callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Custom process specifications can be added to the process builder after first initialization.
-- The process builder supports implicitly wrapping an array returned from a callback using `array_create` process.
+- The process builder supports implicitly wrapping:
+  - an array returned from a callback using the `array_create` process.
+  - non-objects (e.g. numbers) returned from a callback using the `constant` process.
 
 ## [1.2.0] - 2021-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The process builder supports implicitly using `array_create` to wrap an array returned from a callback.
+
 ## [1.2.0] - 2021-03-11
 
 ### Added

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -1525,6 +1525,7 @@ declare module OpenEO {
          */
         constructor(processes: Array<Process> | Processes, parent?: Builder | null, id?: string);
         /**
+         * List of all process specifications.
          * @type {Array.<Process>}
          */
         processes: Array<Process>;
@@ -1553,6 +1554,13 @@ declare module OpenEO {
          * @type {string}
          */
         public id: string;
+        /**
+         * Adds a process specification to the builder so that it can be used to create a process graph.
+         *
+         * @param {Process} process - Process specification compliant to openEO API
+         * @throws {Error}
+         */
+        addProcessSpec(process: Process): void;
         /**
          * Sets the parent for this Builder.
          *
@@ -1602,6 +1610,13 @@ declare module OpenEO {
          * @see Formula
          */
         math(formula: string): BuilderNode;
+        /**
+         * Checks whether a process with the given id is supported by the back-end.
+         *
+         * @param {string} processId - The id of the process to call.
+         * @returns {boolean}
+         */
+        supports(processId: string): boolean;
         /**
          * Adds another process call to the process chain.
          *

--- a/src/builder/builder.js
+++ b/src/builder/builder.js
@@ -104,19 +104,11 @@ class Builder {
 	 * @param {string} id - A unique identifier for the process.
 	 */
 	constructor(processes, parent = null, id = undefined) {
-		if (Array.isArray(processes)) {
-			/**
-			 * @type {Array.<Process>}
-			 */
-			this.processes = processes;
-		}
-		else if (Utils.isObject(processes) && Array.isArray(processes.processes)) {
-			this.processes = processes.processes;
-		}
-		else {
-			throw new Error("Processes are invalid; must be array or object according to API.");
-		}
-
+		/**
+		 * List of all process specifications.
+		 * @type {Array.<Process>}
+		 */
+		this.processes = [];
 		/**
 		 * The parent builder.
 		 * @type {?Builder}
@@ -145,25 +137,51 @@ class Builder {
 		 */
 		this.id = id;
 
-		for(let process of this.processes) {
-			if (typeof this[process.id] === 'undefined') {
-				/**
-				 * Implicitly calls the process with the given name on the back-end by adding it to the process.
-				 * 
-				 * This is a shortcut for {@link Builder#process}.
-				 * 
-				 * @param {...*} args - The arguments for the process.
-				 * @returns {BuilderNode}
-				 * @see Builder#process
-				 */
-				this[process.id] = function(...args) {
-					// Don't use arrow functions, they don't support the arguments keyword.
-					return this.process(process.id, args);
-				};
+		if (Utils.isObject(processes) && Array.isArray(processes.processes)) {
+			processes = processes.processes;
+		}
+		if (Array.isArray(processes)) {
+			for(let process of processes) {
+				try {
+					this.addProcessSpec(process);
+				} catch (error) {
+					console.warn(error);
+				}
 			}
-			else {
-				console.warn("Can't create function for process '" + process.id + "'. Already exists in Builder class.");
-			}
+		}
+		else {
+			throw new Error("Processes are invalid; must be array or object according to the API.");
+		}
+	}
+
+	/**
+	 * Adds a process specification to the builder so that it can be used to create a process graph.
+	 * 
+	 * @param {Process} process - Process specification compliant to openEO API
+	 * @throws {Error}
+	 */
+	addProcessSpec(process) {
+		if (!Utils.isObject(process)) {
+			throw new Error("Process '" + process.id + "' must be an object.");
+		}
+		if (typeof this[process.id] === 'undefined') {
+			this.processes.push(process);
+			/**
+			 * Implicitly calls the process with the given name on the back-end by adding it to the process.
+			 * 
+			 * This is a shortcut for {@link Builder#process}.
+			 * 
+			 * @param {...*} args - The arguments for the process.
+			 * @returns {BuilderNode}
+			 * @see Builder#process
+			 */
+			this[process.id] = function(...args) {
+				// Don't use arrow functions, they don't support the arguments keyword.
+				return this.process(process.id, args);
+			};
+		}
+		else {
+			throw new Error("Can't create function for process '" + process.id + "'. Already exists in Builder class.");
 		}
 	}
 
@@ -269,6 +287,16 @@ class Builder {
 		let math = new Formula(formula);
 		math.setBuilder(this);
 		return math.generate(false);
+	}
+
+	/**
+	 * Checks whether a process with the given id is supported by the back-end.
+	 * 
+	 * @param {string} processId - The id of the process to call.
+	 * @returns {boolean}
+	 */
+	supports(processId) {
+		return Utils.isObject(this.spec(processId));
 	}
 
 	/**

--- a/src/builder/node.js
+++ b/src/builder/node.js
@@ -202,8 +202,11 @@ class BuilderNode {
 		let params = builder.getParentCallbackParameters();
 		// Bind builder to this, so that this.xxx can be used for processes
 		let node = arg.bind(builder)(...params);
-		if (builder.supports('array_create') && Array.isArray(node)) {
+		if (Array.isArray(node) && builder.supports('array_create')) {
 			node = builder.array_create(node);
+		}
+		else if (!Utils.isObject(node) && builder.supports('constant')) {
+			node = builder.constant(node);
 		}
 		if (node instanceof BuilderNode) {
 			node.result = true;

--- a/src/builder/node.js
+++ b/src/builder/node.js
@@ -202,6 +202,9 @@ class BuilderNode {
 		let params = builder.getParentCallbackParameters();
 		// Bind builder to this, so that this.xxx can be used for processes
 		let node = arg.bind(builder)(...params);
+		if (builder.supports('array_create') && Array.isArray(node)) {
+			node = builder.array_create(node);
+		}
 		if (node instanceof BuilderNode) {
 			node.result = true;
 			return builder.toJSON();

--- a/src/builder/parameter.js
+++ b/src/builder/parameter.js
@@ -58,7 +58,7 @@ class Parameter {
 							let args = {
 								data: parameter
 							};
-							if ((typeof name === 'string' && name.match(/^(0|[1-9]\d*)$/))) {
+							if (typeof name === 'string' && name.match(/^(0|[1-9]\d*)$/)) {
 								args.index = parseInt(name, 10);
 							}
 							else {

--- a/tests/builder.array_create.test.js
+++ b/tests/builder.array_create.test.js
@@ -1,0 +1,73 @@
+// @ts-nocheck
+describe('Process Graph Builder (array_create)', () => {
+
+	const { Builder } = require('../src/openeo');
+	const expectedProcess = require('./data/builder.array_create.example.json');
+	const array_create = {
+		"id": "array_create",
+		"description": "Creates a new array, which by default is empty.\n\nThe second parameter `repeat` allows to add the given array multiple times to the new array.\n\nIn most cases you can simply pass a (native) array to processes directly, but this process is especially useful to create a new array that is getting returned by a child process, for example in ``apply_dimension()``.",
+		"parameters": [
+			{
+				"name": "data",
+				"description": "A (native) array to fill the newly created array with. Defaults to an empty array.",
+				"optional": true,
+				"default": [],
+				"schema": {
+					"description": "Any data type is allowed."
+				}
+			},
+			{
+				"name": "repeat",
+				"description": "The number of times the (native) array specified in `data` is repeatedly added after each other to the new array being created. Defaults to `1`.",
+				"optional": true,
+				"default": 1,
+				"schema": {
+					"type": "integer",
+					"minimum": 1
+				}
+			}
+		],
+		"returns": {
+			"description": "The newly created array.",
+			"schema": {
+				"type": "array",
+				"items": {
+					"description": "Any data type is allowed."
+				}
+			}
+		}
+	};
+
+	var builder;
+	test('Add array_create to builder', async () => {
+		// Create builder
+		builder = await Builder.fromVersion('1.0.0');	
+		expect(builder instanceof Builder).toBeTruthy();
+
+		// Add missing process array_create
+		builder.addProcessSpec(array_create);
+		// Check that process is supported now
+		expect(builder.supports('array_create')).toBeTruthy();
+		// Check that process has been added correctly
+		expect(builder.spec('array_create')).toEqual(array_create);
+
+	});
+
+	test('Implicit array_create in callbacks', () => {
+		// Create process (graph)
+		var datacube = builder.load_collection("EXAMPLE", null, null);
+	
+		var process = function(data) {
+			return [data[0], 1];
+		};
+		var result = builder.apply_dimension(datacube, process, "bands");
+		result.result = true;
+
+		let pg = builder.toJSON();
+
+		// Check result
+		expect(pg).toEqual(expectedProcess);
+
+	});
+
+});

--- a/tests/data/builder.array_create.example.json
+++ b/tests/data/builder.array_create.example.json
@@ -1,0 +1,47 @@
+{
+	"process_graph": {
+		"loadco1": {
+			"process_id": "load_collection",
+			"arguments": {
+				"id": "EXAMPLE",
+				"spatial_extent": null,
+				"temporal_extent": null
+			}
+		},
+		"applyd1": {
+			"process_id": "apply_dimension",
+			"arguments": {
+				"data": {
+					"from_node": "loadco1"
+				},
+				"process": {
+					"process_graph": {
+						"arraye1": {
+							"process_id": "array_element",
+							"arguments": {
+								"data": {
+									"from_parameter": "data"
+								},
+								"index": 0
+							}
+						},
+						"arrayc1": {
+							"process_id": "array_create",
+							"arguments": {
+								"data": [
+									{
+										"from_node": "arraye1"
+									},
+									1
+								]
+							},
+							"result": true
+						}
+					}
+				},
+				"dimension": "bands"
+			},
+			"result": true
+		}
+	}
+}


### PR DESCRIPTION
The process builder supports implicitly using array_create to wrap an array returned from a callback.

Related PR: https://github.com/Open-EO/openeo-processes/pull/218