### PR TITLE
Release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,14 +105,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 All prior releases have been documented in the [GitHub Releases](https://github.com/Open-EO/openeo-js-client/releases).
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.2...v2.0.0
-[1.3.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.1...v1.3.2
-[1.3.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.0...v1.3.1
-[1.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.3...v1.1.0
-[1.0.3]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.2...v1.0.3
-[1.0.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.1...v1.0.2
-[1.0.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0...v1.0.1
-[1.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.0.0-rc.5...v1.0.0
+[Unreleased]: https://github.com/Open-EO/openeo-js-client/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/Open-EO/openeo-js-client/compare/v1.3.2...v2.0.0
+[1.3.2]: https://github.com/Open-EO/openeo-js-client/compare/v1.3.1...v1.3.2
+[1.3.1]: https://github.com/Open-EO/openeo-js-client/compare/v1.3.0...v1.3.1
+[1.3.0]: https://github.com/Open-EO/openeo-js-client/compare/v1.2.0...v1.3.0
+[1.2.0]: https://github.com/Open-EO/openeo-js-client/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/Open-EO/openeo-js-client/compare/v1.0.3...v1.1.0
+[1.0.3]: https://github.com/Open-EO/openeo-js-client/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/Open-EO/openeo-js-client/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/Open-EO/openeo-js-client/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/Open-EO/openeo-js-client/compare/v1.0.0-rc.5...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - OpenID Connect authentication has been rewritten.
 - Default grant type for OpenID Connect is "AuthCode w/ PKCE" instead of "Implicit".
 - Support for OpenID Connect session renewal via refresh tokens.
+- Updated STAC support to STAC v1.0.0.
 
 ### Removed
 
 - `OidcProvider`: Methods `getGrant`, `getScopes`, `getIssuer` and `getUser` removed. Use the properties `grant`, `scopes`, `issuer` and `user` instead.
+- Removed deprecated method `getResultsAsItem` in favor of `getResultsAsStac`.
 
 ## [1.3.2] - 2021-05-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2021-05-30
+## [2.0.0] - 2021-07-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2021-05-30
+
+### Added
+
+- Added events to `Connection` to populate changes for Auth Tokens (`tokenChanged`) and Auth Providers (`authProviderChanged`).
+- Added new methods to `Connection` for working with events: `on`, `off` and `emit`.
+
+### Changed
+
+- OpenID Connect authentication has been rewritten.
+- Default grant type for OpenID Connect is "AuthCode w/ PKCE" instead of "Implicit".
+- Support for OpenID Connect session renewal via refresh tokens.
+
+### Removed
+
+- `OidcProvider`: Methods `getGrant`, `getScopes`, `getIssuer` and `getUser` removed. Use the properties `grant`, `scopes`, `issuer` and `user` instead.
+
 ## [1.3.2] - 2021-05-27
 
 ### Fixed
@@ -86,7 +103,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 All prior releases have been documented in the [GitHub Releases](https://github.com/Open-EO/openeo-js-client/releases).
 
-[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.2...HEAD
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.2...v2.0.0
 [1.3.2]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/olivierlacan/keep-a-changelog/compare/v1.2.0...v1.3.0

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 JavaScript/TypeScript client for the openEO API.
 
-* [Documentation](https://open-eo.github.io/openeo-js-client/1.3.2/).
+* [Documentation](https://open-eo.github.io/openeo-js-client/2.0.0/).
 
-The version of this client is **1.3.2** and supports **openEO API versions 1.x.x**.
+The version of this client is **2.0.0** and supports **openEO API versions 1.x.x**.
 Legacy versions are available as releases.
 See the [CHANGELOG](CHANGELOG.md) for recent changes.
 
@@ -20,7 +20,7 @@ To use it in a browser environment simply add the following code to your HTML fi
 ```html
 <script src="https://cdn.jsdelivr.net/npm/axios@0.21/dist/axios.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/oidc-client@1/dist/oidc-client.min.js"></script> <!-- Only required if you'd like to enable authentication via OpenID Connect -->
-<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@1/openeo.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@2/openeo.min.js"></script>
 ```
 
 ### NodeJS
@@ -53,7 +53,7 @@ In Node.js:
 In Typescript:
 * [Basic Discovery (promises)](examples/typescript/discovery.ts)
 
-More information can be found in the [documentation](https://open-eo.github.io/openeo-js-client/1.3.2/).
+More information can be found in the [documentation](https://open-eo.github.io/openeo-js-client/2.0.0/).
 
 ## Development
 

--- a/examples/oidc/openid-connect-popup.html
+++ b/examples/oidc/openid-connect-popup.html
@@ -7,14 +7,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.jsdelivr.net/npm/axios@0.19/dist/axios.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/oidc-client@1/dist/oidc-client.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@1/openeo.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@2/openeo.min.js"></script>
   <script type="text/javascript">
     const BACKEND = "https://example.openeo.org"; // TODO: Set the back-end to authenticate against
     const CLIENT_ID = ""; // TODO: Set the client id
-    const REDIRECT_URI = "http://localhost/openid-connect-popup.html?signin"; // TODO: Set the redirect URI, should include ?signin - doesn't work with file://
-
+    OidcProvider.redirectUrl = "http://localhost/openid-connect-popup.html?signin"; // TODO: Set the redirect URI, should include ?signin - doesn't work with file://
     // Set the UI method, here we open a popup
-    OidcProvider.setUiMethod("popup");
+    OidcProvider.uiMethod = "popup";
 
     var con;
     async function run() {
@@ -59,9 +58,12 @@
         var providers = await con.listAuthProviders();
         var provider = providers.find(p => p.getId() === id);
 
+        // Set the client ID
+        provider.setClientId(CLIENT_ID);
+
         // Start the login procedure (opens a popup as configured above)
         // Then waits for the popup to be closed
-        await provider.login(CLIENT_ID, REDIRECT_URI);
+        await provider.login();
 
         // After the popup is closed, check whether the user is now authenticated
         if (con.isAuthenticated()) {

--- a/examples/oidc/openid-connect-redirect.html
+++ b/examples/oidc/openid-connect-redirect.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.jsdelivr.net/npm/axios@0.19/dist/axios.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/oidc-client@1/dist/oidc-client.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@1/openeo.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@2/openeo.min.js"></script>
   <script type="text/javascript">
     const BACKEND = "https://example.openeo.org"; // TODO: Set the back-end to authenticate against
     const CLIENT_ID = ""; // TODO: Set the client id
@@ -78,8 +78,12 @@
         var providers = await con.listAuthProviders();
         var provider = providers.find(p => p.getId() === id);
 
-        // Start the login procedure (redirects to the identity provider by default)
-        await provider.login(CLIENT_ID, REDIRECT_URI + id);
+        // Set the client ID and redirect URI
+        provider.setClientId(CLIENT_ID);
+        OidcProvider.redirectUri = REDIRECT_URI + id;
+
+        // Start the login procedure (redirects to the identity provider)
+        await provider.login();
       } catch (e) {
         log("Error: " + e.message);
       }

--- a/examples/web/discovery.html
+++ b/examples/web/discovery.html
@@ -6,7 +6,7 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<script src="https://cdn.jsdelivr.net/npm/axios@0.19/dist/axios.min.js"></script>
-	<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@1/openeo.min.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@2/openeo.min.js"></script>
 	<script type="text/javascript">
 		var url = "https://earthengine.openeo.org"; // Insert the openEO server URL here
 		var connection = null;

--- a/examples/web/workflow.html
+++ b/examples/web/workflow.html
@@ -6,7 +6,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script src="https://cdn.jsdelivr.net/npm/axios@0.19/dist/axios.min.js"></script>
-  <script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@1/openeo.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@openeo/js-client@2/openeo.min.js"></script>
   <script type="text/javascript">
     async function run() {
       // Show the client version

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -79,7 +79,7 @@ declare module OpenEO {
         /**
          * Abstract method that extending classes implement the login process with.
          *
-         * @param  {...*} args
+         * @param {...*} args
          * @throws {Error}
          */
         login(...args: any[]): Promise<void>;
@@ -196,6 +196,20 @@ declare module OpenEO {
          * @static
          */
         static getName(): string;
+        /**
+         * Returns the URL of the Environment.
+         *
+         * @returns {string}
+         * @static
+         */
+        static getUrl(): string;
+        /**
+         * Sets the URL of the Environment.
+         *
+         * @param {string} uri
+         * @static
+         */
+        static setUrl(uri: string): void;
         /**
          * Handles errors from the API that are returned as Blobs/Streams.
          *
@@ -396,7 +410,6 @@ declare module OpenEO {
      *
      * @augments AuthProvider
      * @see Connection#setOidcProviderFactory
-     * @todo Default grant is "implicit" in JS Client 1.0, change to "authorization_code+pkce" in 2.0.
      */
     export class OidcProvider extends AuthProvider {
         /**
@@ -407,44 +420,21 @@ declare module OpenEO {
          */
         static isSupported(): boolean;
         /**
-         * Globally sets the UI method (redirect, popup) to use for OIDC authentication.
-         *
-         * @static
-         * @param {string} method - Method how to load and show the authentication process. Either `popup` (opens a popup window) or `redirect` (HTTP redirects, default).
-         */
-        static setUiMethod(method: string): void;
-        /**
-         * Get the response_type based on the grant type.
-         *
-         * @static
-         * @param {string} grant - Grant Type
-         * @returns {string}
-         * @throws {Error}
-         */
-        static getResponseType(grant: string): string;
-        /**
-         * Globally sets the supported OpenID Connect grants (flows) to use.
-         *
-         * Lists them by priority so that the first grant is the default grant.
-         *
-         * @static
-         * @param {Array.<string>} grants - Grants as defined in OpenID Connect Discovery, e.g. `implicit` and/or `authorization_code+pkce`
-         */
-        static setSupportedGrants(grants: Array<string>): void;
-        /**
          * Finishes the OpenID Connect sign in (authentication) workflow.
          *
          * Must be called in the page that OpenID Connect redirects to after logging in.
+         *
+         * Supported only in Browser environments.
          *
          * @async
          * @static
          * @param {OidcProvider} provider - A OIDC provider to assign the user to.
          * @param {object.<string, *>} [options={}] - Object with additional options.
-         * @returns {Promise<User>} For uiMethod = 'redirect' only: OIDC User (to be assigned to the Connection via setUser if no provider has been specified). 
+         * @returns {Promise<?User>} For uiMethod = 'redirect' only: OIDC User
          * @throws {Error}
          * @see https://github.com/IdentityModel/oidc-client-js/wiki#other-optional-settings
          */
-        static signinCallback(provider?: OidcProvider, options?: any): Promise<User>;
+        static signinCallback(provider?: OidcProvider, options?: any): Promise<User | null>;
         /**
          * Creates a new OidcProvider instance to authenticate using OpenID Connect.
          *
@@ -452,13 +442,97 @@ declare module OpenEO {
          * @param {OidcProviderMeta} options - OpenID Connect Provider details as returned by the API.
          */
         constructor(connection: Connection, options: OidcProviderMeta);
-        issuer: string;
-        scopes: string[];
-        links: Link[];
-        defaultClients: OidcClient[];
-        grant: string;
         manager: UserManager;
-        user: User;
+        listeners: {};
+        /**
+         * The authenticated OIDC user.
+         *
+         * @type {User}
+         */
+        user: Oidc.User;
+        /**
+         * The client ID to use for authentication.
+         *
+         * @type {?string}
+         */
+        clientId: string | null;
+        /**
+         * The grant type (flow) to use for this provider.
+         *
+         * Either "authorization_code+pkce" (default) or "implicit"
+         *
+         * @type {string}
+         */
+        grant: string;
+        /**
+         * The issuer, i.e. the link to the identity provider.
+         *
+         * @type {string}
+         */
+        issuer: string;
+        /**
+         * The scopes to be requested.
+         *
+         * @type {Array.<string>}
+         */
+        scopes: Array<string>;
+        /**
+         * Any additional links.
+         *
+         *
+         * @type {Array.<Link>}
+         */
+        links: Array<Link>;
+        /**
+         * The default clients made available by the back-end.
+         *
+         * @type {Array.<OidcClient>}
+         */
+        defaultClients: Array<OidcClient>;
+        /**
+         * The detected default Client.
+         *
+         * @type {OidcClient}
+         */
+        defaultClient: OidcClient;
+        /**
+         * Adds a listener to one of the following events:
+         *
+         * - AccessTokenExpiring: Raised prior to the access token expiring.
+         * - accessTokenExpired: Raised after the access token has expired.
+         * - silentRenewError: Raised when the automatic silent renew has failed.
+         *
+         * @param {string} event
+         * @param {Function} callback
+         * @param {string} [scope="default"]
+         */
+        addListener(event: string, callback: Function, scope?: string): void;
+        /**
+         * Removes the listener for the given event that has been set with addListener.
+         *
+         * @param {string} event
+         * @param {string} [scope="default"]
+         * @see OidcProvider#addListener
+         */
+        removeListener(event: string, scope?: string): void;
+        /**
+         * Returns the options for the OIDC client library.
+         *
+         * Options can be overridden by custom options via the options parameter.
+         *
+         * @protected
+         * @param {object.<string, *>} options
+         * @returns {object.<string, *>}
+         */
+        protected getOptions(options?: any): any;
+        /**
+         * Get the response_type based on the grant type.
+         *
+         * @protected
+         * @returns {string}
+         * @throws {Error}
+         */
+        protected getResponseType(): string;
         /**
          * Sets the grant type (flow) used for OIDC authentication.
          *
@@ -467,50 +541,35 @@ declare module OpenEO {
          */
         setGrant(grant: string): void;
         /**
-         * Returns the grant type (flow) used for OIDC authentication.
+         * Sets the Client ID for OIDC authentication.
          *
-         * @returns {string}
+         * This may override a detected default client ID.
+         *
+         * @param {?string} clientId
          */
-        getGrant(): string;
-        /**
-         * Returns the OpenID Connect / OAuth scopes.
-         *
-         * @returns {Array.<string>}
-         */
-        getScopes(): Array<string>;
-        /**
-         * Returns the OpenID Connect / OAuth issuer.
-         *
-         * @returns {string}
-         */
-        getIssuer(): string;
-        /**
-         * Returns the OpenID Connect user instance retrieved from the OIDC client library.
-         *
-         * @returns {User}
-         */
-        getUser(): User;
-        /**
-         * Detects the default OIDC client ID for the given redirect URL.
-         *
-         * Sets the grant accordingly.
-         *
-         * @param {string} redirectUrl - Redirect URL
-         * @returns {?string}
-         * @see OidcProvider#setGrant
-         */
-        detectDefaultClient(redirectUrl: string): string | null;
+        setClientId(clientId: string | null): void;
         /**
          * Sets the OIDC User.
          *
          * @see https://github.com/IdentityModel/oidc-client-js/wiki#user
-         * @param {User} user - The OIDC User returned by OidcProvider.signinCallback(). Passing `null` resets OIDC authentication details.
+         * @param {?User} user - The OIDC User. Passing `null` resets OIDC authentication details.
          */
-        setUser(user: User): void;
+        setUser(user: User | null): void;
+        /**
+         * Detects the default OIDC client ID for the given redirect URL.
+         *
+         * Sets the grant and client ID accordingly.
+         *
+         * @returns {?OidcClient}
+         * @see OidcProvider#setGrant
+         * @see OidcProvider#setClientId
+         */
+        detectDefaultClient(): OidcClient | null;
     }
     export namespace OidcProvider {
         const uiMethod: string;
-        const grants: string[];
+        const redirectUrl: string;
+        const grants: Array<string>;
     }
     /**
      * Manages the files types supported by the back-end.
@@ -1531,22 +1590,22 @@ declare module OpenEO {
      *
      * var storedProcess = await con.setUserProcess("evi", datacube);
      * ```
-     * 
+     *
      * As you can see above, the builder in callback functions is available as `this`.
      * Arrow functions do not support rebinding this and therefore the builder is passed as the last argument.
-     * 
+     *
      * So a normal function can be defined as follows:
      * ```
      * let callback = function(data) {
      *   return this.mean(data);
      * }
      * ```
-     * 
+     *
      * An arrow function on the other hand has to use the builder that is passed as the last parameter:
      * ```
      * let callback = (data, c, builder) => builder.mean(data);
      * ```
-     * 
+     *
      * Using arrow functions is available only since JS client version 1.3.0.
      * Beforehand it was not possible to use arrow functions in this context.
      */
@@ -1733,6 +1792,7 @@ declare module OpenEO {
          */
         capabilitiesObject: Capabilities | null;
         processes: any;
+        listeners: {};
         /**
          * Initializes the connection by requesting the capabilities.
          *
@@ -1916,6 +1976,31 @@ declare module OpenEO {
          */
         isAuthenticated(): boolean;
         /**
+         * Emits the given event.
+         *
+         * @protected
+         * @param {string} event
+         * @param {...*} args
+         */
+        protected emit(event: string, ...args: any[]): void;
+        /**
+         * Registers a listener with the given event.
+         *
+         * Currently supported:
+         * - authProviderChanged(provider): Raised when the auth provider has changed.
+         * - tokenChanged(token): Raised when the access token has changed.
+         *
+         * @param {string} event
+         * @param {Function} callback
+         */
+        on(event: string, callback: Function): void;
+        /**
+         * Removes a listener from the given event.
+         *
+         * @param {string} event
+         */
+        off(event: string): void;
+        /**
          * Returns the AuthProvider.
          *
          * @returns {?AuthProvider}
@@ -1924,10 +2009,7 @@ declare module OpenEO {
         /**
          * Sets the AuthProvider.
          *
-         * The provider must have a token set.
-         *
          * @param {AuthProvider} provider
-         * @throws {Error}
          */
         setAuthProvider(provider: AuthProvider): void;
         /**
@@ -2488,6 +2570,10 @@ declare module OpenEO {
          * OpenID Connect Scopes
          */
         scopes: Array<string>;
+        /**
+         * Default OpenID Connect Clients
+         */
+        default_clients: Array<OidcClient>;
         /**
          * Links
          */

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -934,20 +934,9 @@ declare module OpenEO {
          */
         stopJob(): Promise<Job>;
         /**
-         * Retrieves the STAC Item produced for the job results.
-         *
-         * The Item returned always complies to the latest STAC version (currently 1.0.0-rc.1).
-         *
-         * @async
-         * @returns {Promise<object.<string, *>>} The JSON-based response compatible to the API specification, but also including a `costs` property if present in the headers.
-         * @throws {Error}
-         * @deprecated
-         */
-        getResultsAsItem(): Promise<any>;
-        /**
          * Retrieves the STAC Item or Collection produced for the job results.
          *
-         * The Item or Collection returned always complies to the latest STAC version (currently 1.0.0-rc.1).
+         * The Item or Collection returned always complies to the latest STAC version (currently 1.0.0).
          *
          * @async
          * @returns {Promise<object.<string, *>>} The JSON-based response compatible to the API specification, but also including a `costs` property if present in the headers.
@@ -1839,7 +1828,7 @@ declare module OpenEO {
         /**
          * List all collections available on the back-end.
          *
-         * The collections returned always comply to the latest STAC version (currently 1.0.0-rc.1).
+         * The collections returned always comply to the latest STAC version (currently 1.0.0).
          *
          * @async
          * @returns {Promise<Collections>} A response compatible to the API specification.
@@ -1849,7 +1838,7 @@ declare module OpenEO {
         /**
          * Get further information about a single collection.
          *
-         * The collection returned always complies to the latest STAC version (currently 1.0.0-rc.1).
+         * The collection returned always complies to the latest STAC version (currently 1.0.0).
          *
          * @async
          * @param {string} collectionId - Collection ID to request further metadata for.
@@ -1861,7 +1850,7 @@ declare module OpenEO {
          * Loads items for a specific image collection.
          * May not be available for all collections.
          *
-         * The items returned always comply to the latest STAC version (currently 1.0.0-rc.1).
+         * The items returned always comply to the latest STAC version (currently 1.0.0).
          *
          * This is an experimental API and is subject to change.
          *

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openeo/js-client",
-  "version": "1.3.2",
+  "version": "2.0.0",
   "author": "openEO Consortium",
   "contributors": [
     {
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "@openeo/js-commons": "^1.2.0",
-    "@radiantearth/stac-migrate": "^1.0.0-rc.3",
+    "@radiantearth/stac-migrate": "^1.0.0",
     "axios": "^0.21.1",
     "oidc-client": "^1.11.5"
   },

--- a/src/authprovider.js
+++ b/src/authprovider.js
@@ -101,18 +101,19 @@ class AuthProvider {
 	 */
 	setToken(token) {
 		this.token = token;
+		this.connection.emit('tokenChanged', token);
 		if (this.token !== null) {
-			this.connection.authProvider = this;
+			this.connection.setAuthProvider(this);
 		}
 		else {
-			this.connection.authProvider = null;
+			this.connection.setAuthProvider(null);
 		}
 	}
 
 	/**
 	 * Abstract method that extending classes implement the login process with.
 	 * 
-	 * @param  {...*} args 
+	 * @param {...*} args 
 	 * @throws {Error}
 	 */
 	async login(...args) {

--- a/src/browser.js
+++ b/src/browser.js
@@ -18,6 +18,28 @@ class Environment {
 	}
 
 	/**
+	 * Returns the current URL of the browser window.
+	 * 
+	 * @returns {string}
+	 * @static
+	 */
+	static getUrl() {
+		return window.location.toString();
+	}
+
+	/**
+	 * Sets the URL.
+	 * 
+	 * Not supported in Browsers and only throws an Error!
+	 * 
+	 * @param {string} uri
+	 * @static
+	 */
+	static setUrl(uri) { // eslint-disable-line no-unused-vars
+		throw new Error("setUrl is not supported in a browser environment.");
+	}
+
+	/**
 	 * Handles errors from the API that are returned as Blobs.
 	 * 
 	 * @ignore

--- a/src/connection.js
+++ b/src/connection.js
@@ -117,7 +117,7 @@ class Connection {
 	/**
 	 * List all collections available on the back-end.
 	 * 
-	 * The collections returned always comply to the latest STAC version (currently 1.0.0-rc.1). 
+	 * The collections returned always comply to the latest STAC version (currently 1.0.0). 
 	 * 
 	 * @async
 	 * @returns {Promise<Collections>} A response compatible to the API specification.
@@ -134,7 +134,7 @@ class Connection {
 	/**
 	 * Get further information about a single collection.
 	 * 
-	 * The collection returned always complies to the latest STAC version (currently 1.0.0-rc.1). 
+	 * The collection returned always complies to the latest STAC version (currently 1.0.0). 
 	 * 
 	 * @async
 	 * @param {string} collectionId - Collection ID to request further metadata for.
@@ -150,7 +150,7 @@ class Connection {
 	 * Loads items for a specific image collection.
 	 * May not be available for all collections.
 	 * 
-	 * The items returned always comply to the latest STAC version (currently 1.0.0-rc.1). 
+	 * The items returned always comply to the latest STAC version (currently 1.0.0). 
 	 * 
 	 * This is an experimental API and is subject to change.
 	 * 

--- a/src/connection.js
+++ b/src/connection.js
@@ -45,6 +45,7 @@ class Connection {
 		 */
 		this.capabilitiesObject = null;
 		this.processes = null;
+		this.listeners = {};
 	}
 
 	/**
@@ -371,6 +372,42 @@ class Connection {
 	}
 
 	/**
+	 * Emits the given event.
+	 * 
+	 * @protected
+	 * @param {string} event 
+	 * @param {...*} args
+	 */
+	emit(event, ...args) {
+		if (typeof this.listeners[event] === 'function') {
+			this.listeners[event](...args);
+		}
+	}
+
+	/**
+	 * Registers a listener with the given event.
+	 * 
+	 * Currently supported:
+	 * - authProviderChanged(provider): Raised when the auth provider has changed.
+	 * - tokenChanged(token): Raised when the access token has changed.
+	 * 
+	 * @param {string} event 
+	 * @param {Function} callback 
+	 */
+	on(event, callback) {
+		this.listeners[event] = callback;
+	}
+
+	/**
+	 * Removes a listener from the given event.
+	 * 
+	 * @param {string} event 
+	 */
+	off(event) {
+		delete this.listeners[event];
+	}
+
+	/**
 	 * Returns the AuthProvider.
 	 * 
 	 * @returns {?AuthProvider} 
@@ -382,18 +419,19 @@ class Connection {
 	/**
 	 * Sets the AuthProvider.
 	 * 
-	 * The provider must have a token set.
-	 * 
-	 * @param {AuthProvider} provider 
-	 * @throws {Error}
+	 * @param {AuthProvider} provider
 	 */
 	setAuthProvider(provider) {
-		if (provider instanceof AuthProvider && provider.getToken() !== null) {
+		if (provider === this.authProvider) {
+			return;
+		}
+		if (provider instanceof AuthProvider) {
 			this.authProvider = provider;
 		}
 		else {
-			throw new Error("Invalid auth provider given or no token set.");
+			this.authProvider = null;
 		}
+		this.emit('authProviderChanged', this.authProvider);
 	}
 
 	/**
@@ -411,13 +449,14 @@ class Connection {
 	 * @returns {AuthProvider}
 	 */
 	setAuthToken(type, providerId, token) {
-		this.authProvider = new AuthProvider(type, this, {
+		let provider = new AuthProvider(type, this, {
 			id: providerId,
 			title: "Custom",
 			description: ""
 		});
-		this.authProvider.setToken(token);
-		return this.authProvider;
+		provider.setToken(token);
+		this.setAuthProvider(provider);
+		return provider;
 	}
 
 	/**

--- a/src/job.js
+++ b/src/job.js
@@ -255,44 +255,9 @@ class Job extends BaseEntity {
 	}
 
 	/**
-	 * Retrieves the STAC Item produced for the job results.
-	 * 
-	 * The Item returned always complies to the latest STAC version (currently 1.0.0-rc.1). 
-	 * 
-	 * @async
-	 * @returns {Promise<object.<string, *>>} The JSON-based response compatible to the API specification, but also including a `costs` property if present in the headers.
-	 * @throws {Error}
-	 * @deprecated
-	 */
-	async getResultsAsItem() {
-		let data = await this.getResultsAsStac();
-		if (data.type === 'Feature') { // Item
-			return data;
-		}
-		else { // We got a Collection, try to make a minimal Item from it for backward-compatibility
-			let item = Utils.pickFromObject(data, ['stac_version', 'id', 'assets', 'links']);
-			item.type = 'Feature';
-			item.geometry = null;
-			item.properties = Utils.pickFromObject(data, ['title', 'description', 'license', 'providers', 'created', 'updated', 'expires', 'costs']);
-			item.properties.datetime = null;
-			if (Utils.isObject(data.extent) && Utils.isObject(data.extent.temporal) && Array.isArray(data.extent.temporal.interval) && Array.isArray(data.extent.temporal.interval[0])) {
-				let temp = data.extent.temporal.interval[0];
-				if (typeof temp[0] === 'string' && temp[1] === 'string') {
-					item.properties.start_datetime = temp[0];
-					item.properties.end_datetime = temp[1];
-				}
-				else {
-					item.properties.datetime = temp[0] || temp[1];
-				}
-			}
-			return StacMigrate.item(item);
-		}
-	}
-
-	/**
 	 * Retrieves the STAC Item or Collection produced for the job results.
 	 * 
-	 * The Item or Collection returned always complies to the latest STAC version (currently 1.0.0-rc.1). 
+	 * The Item or Collection returned always complies to the latest STAC version (currently 1.0.0). 
 	 * 
 	 * @async
 	 * @returns {Promise<object.<string, *>>} The JSON-based response compatible to the API specification, but also including a `costs` property if present in the headers.

--- a/src/node.js
+++ b/src/node.js
@@ -23,6 +23,26 @@ class Environment {
 	}
 
 	/**
+	 * Returns the URL of the server instance.
+	 * 
+	 * @returns {string}
+	 * @static
+	 */
+	static getUrl() {
+		return Environment.url;
+	}
+
+	/**
+	 * Sets the URL of the server instance.
+	 * 
+	 * @param {string} uri
+	 * @static
+	 */
+	static setUrl(uri) {
+		Environment.url = uri;
+	}
+
+	/**
 	 * Handles errors from the API that are returned as Streams.
 	 * 
 	 * @ignore
@@ -142,5 +162,7 @@ class Environment {
 		});
 	}
 }
+
+Environment.url = '';
 
 module.exports = Environment;

--- a/src/openeo.js
+++ b/src/openeo.js
@@ -104,7 +104,7 @@ class OpenEO {
 	 * @returns {string} Version number (according to SemVer).
 	 */
 	static clientVersion() {
-		return "1.3.2";
+		return "2.0.0";
 	}
 
 }

--- a/tests/config.js
+++ b/tests/config.js
@@ -1,5 +1,5 @@
 module.exports = {
 //	TESTBACKEND: 'http://127.0.0.1:8080'
 	TESTBACKEND: 'https://earthengine.openeo.org',
-	STAC_MIGRATE_VERSION: '1.0.0-rc.2'
+	STAC_MIGRATE_VERSION: '1.0.0'
 };

--- a/tests/earthengine.test.js
+++ b/tests/earthengine.test.js
@@ -6,10 +6,13 @@ const waitForExpect = require("wait-for-expect");
 var timeout = 2*60*1000;
 jest.setTimeout(timeout); // Give Google some time to process data
 
+// Generate random int
+const random = (min, max) => Math.floor(Math.random() * (max - min)) + min;
+
 describe('With earth-engine-driver', () => {
 	const { TESTBACKEND, STAC_MIGRATE_VERSION } = require('./config.js');
 	const TESTBACKENDDIRECT = TESTBACKEND + '/v1.0';
-	const TESTUSERNAME = 'group5';
+	const TESTUSERNAME = `group${random(20,29)}`;
 	const TESTPASSWORD = 'test123';
 	
 	const FREE_PLAN = {"name":"free","description":"Earth Engine is free for research, education, and nonprofit use. For commercial applications, Google offers paid commercial licenses. Please contact earthengine-commercial@google.com for details.","paid":false};
@@ -184,7 +187,7 @@ describe('With earth-engine-driver', () => {
 		test('Collections in detail', async () => {
 			var coll = await con.describeCollection(TESTCOLLECTION.id);
 			expect(coll.stac_version).toBe(STAC_MIGRATE_VERSION);
-			expect(coll.stac_extensions).toEqual([]);
+			expect(coll.stac_extensions).toEqual(["collection-assets"]);
 			expect(coll.id).toBe(TESTCOLLECTION.id);
 			expect(coll).toHaveProperty('description');
 			expect(coll.license).toBe(TESTCOLLECTION.license);

--- a/tests/eodc.test.js
+++ b/tests/eodc.test.js
@@ -24,7 +24,8 @@ describe('With eodc-driver', () => {
 			expect(typeof con._getLinkHref(col.links, 'items')).toBe("string");
 		});
 
-		test('Request three pages of items', async () => {
+		// Skip this test for now, EODC back-end is not responding
+		test.skip('Request three pages of items', async () => {
 			let page = 1;
 			let spatialExtent = [5.0,45.0,20.0,50.0];
 			let temporalExtent = [Date.UTC(2015, 0, 1), Date.UTC(2017, 0, 1)];


### PR DESCRIPTION
This is v2.0.0 of the openEO JS client.

To improve the OIDC implementation, I had to do some breaking changes, which I wanted to do for a long time but was hesitant to do due to the breaking changes. Now I finally can't avoid them.

I also removed the deprecated method for STAC Items.

See the changelog for details.

@christophfriedrich Please review this PR, especially the OIDC examples.