### PR TITLE
fix: added a function to normalize the namespace in case of UDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The `namespace` parameter in `listProcesses` and `describeProcess` parses URLs to extract the namespace (experimental).
+
 ## [2.3.1] - 2021-12-10
 
 ### Fixed

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -1956,6 +1956,20 @@ declare module OpenEO {
          */
         listCollectionItems(collectionId: string, spatialExtent?: Array<number> | null, temporalExtent?: Array<any> | null, limit?: number | null): AsyncGenerator<any, void, unknown>;
         /**
+         * Normalisation of the namespace to a value that is compatible with the OpenEO specs - EXPERIMENTAL.
+         *
+         * This is required to support UDP that are shared as public. These can only be executed with providing the full URL
+         * (e.g. https://<backend>/processes/u:<user>/<udp_id>) as the namespace value in the processing graph. For other
+         * parts of the API (such as the listing of the processes, only the name of the namespace is required (u:<user>).
+         *
+         * This function will extract the short name of the namespace from a shareable URL.
+         *
+         * @protected
+         * @param {?string} namespace - Namespace of the process
+         * @returns {?string}
+         */
+        protected normalizeNamespace(namespace: string | null): string | null;
+        /**
          * List processes available on the back-end.
          *
          * Requests pre-defined processes by default.

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -1959,8 +1959,8 @@ declare module OpenEO {
          * Normalisation of the namespace to a value that is compatible with the OpenEO specs - EXPERIMENTAL.
          *
          * This is required to support UDP that are shared as public. These can only be executed with providing the full URL
-         * (e.g. https://<backend>/processes/u:<user>/<udp_id>) as the namespace value in the processing graph. For other
-         * parts of the API (such as the listing of the processes, only the name of the namespace is required (u:<user>).
+         * (e.g. https://<backend>/processes/<namespace>/<process_id>) as the namespace value in the processing graph. For other
+         * parts of the API (such as the listing of the processes, only the name of the namespace is required.
          *
          * This function will extract the short name of the namespace from a shareable URL.
          *

--- a/src/connection.js
+++ b/src/connection.js
@@ -305,7 +305,7 @@ class Connection {
 	 */
 	normalizeNamespace(namespace) {
 		// The pattern in https://github.com/Open-EO/openeo-api/pull/348 doesn't include the double colon yet - the regexp may change in the future
-		const matches = namespace.match( /^https?:\/\/.*\/processes\/(@?[\w\-\.~:]+)\/?/i);
+		const matches = namespace.match( /^https?:\/\/.*\/processes\/(@?[\w\-.~:]+)\/?/i);
 		return matches && matches.length > 1 ? matches[1] : namespace;
 	}
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -294,8 +294,8 @@ class Connection {
 	 * Normalisation of the namespace to a value that is compatible with the OpenEO specs - EXPERIMENTAL.
 	 *
 	 * This is required to support UDP that are shared as public. These can only be executed with providing the full URL
-	 * (e.g. https://<backend>/processes/u:<user>/<udp_id>) as the namespace value in the processing graph. For other
-	 * parts of the API (such as the listing of the processes, only the name of the namespace is required (u:<user>).
+	 * (e.g. https://<backend>/processes/<namespace>/<process_id>) as the namespace value in the processing graph. For other
+	 * parts of the API (such as the listing of the processes, only the name of the namespace is required.
 	 *
 	 * This function will extract the short name of the namespace from a shareable URL.
 	 * 

--- a/src/connection.js
+++ b/src/connection.js
@@ -300,8 +300,8 @@ class Connection {
 	 * This function will extract the short name of the namespace from a shareable URL.
 	 * 
 	 * @protected
-	 * @param {string} namespace - Namespace of the process
-	 * @returns {*}
+	 * @param {?string} namespace - Namespace of the process
+	 * @returns {?string}
 	 */
 	normalizeNamespace(namespace) {
 		// The pattern in https://github.com/Open-EO/openeo-api/pull/348 doesn't include the double colon yet - the regexp may change in the future

--- a/src/connection.js
+++ b/src/connection.js
@@ -303,7 +303,7 @@ class Connection {
 	 */
 	normalizeNamespace(namespace) {
 		if (namespace.includes('u:')) {
-			const regex = /(u:[\d\w]*)[\/]?/;
+			const regex = /(u:[\d\w]*)[/]?/;
 			return namespace.match(regex)[1] || namespace;
 		} else {
 			return namespace;

--- a/src/connection.js
+++ b/src/connection.js
@@ -302,7 +302,8 @@ class Connection {
 	 * @returns {*}
 	 */
 	normalizeNamespace(namespace) {
-		const matches = namespace.match( /^http[s]?:\/\/.*\/processes\/(u:[\d\w]*)\/?/);
+		// The pattern in https://github.com/Open-EO/openeo-api/pull/348 doesn't include the double colon yet - the regexp may change in the future
+		const matches = namespace.match( /^https?:\/\/.*\/processes\/(@?[\w\-\.~:]+)\/?/i);
 		return matches && matches.length > 1 ? matches[1] : namespace;
 	}
 

--- a/src/connection.js
+++ b/src/connection.js
@@ -298,7 +298,9 @@ class Connection {
 	 * parts of the API (such as the listing of the processes, only the name of the namespace is required (u:<user>).
 	 *
 	 * This function will extract the short name of the namespace from a shareable URL.
-	 * @param namespace
+	 * 
+	 * @protected
+	 * @param {string} namespace - Namespace of the process
 	 * @returns {*}
 	 */
 	normalizeNamespace(namespace) {

--- a/src/connection.js
+++ b/src/connection.js
@@ -291,7 +291,7 @@ class Connection {
 	}
 
 	/**
-	 * Normalisation of the namespace to a value that is compatible with the OpenEO specs.
+	 * Normalisation of the namespace to a value that is compatible with the OpenEO specs - EXPERIMENTAL.
 	 *
 	 * This is required to support UDP that are shared as public. These can only be executed with providing the full URL
 	 * (e.g. https://<backend>/processes/u:<user>/<udp_id>) as the namespace value in the processing graph. For other

--- a/src/connection.js
+++ b/src/connection.js
@@ -302,12 +302,8 @@ class Connection {
 	 * @returns {*}
 	 */
 	normalizeNamespace(namespace) {
-		if (namespace.includes('u:')) {
-			const regex = /(u:[\d\w]*)[/]?/;
-			return namespace.match(regex)[1] || namespace;
-		} else {
-			return namespace;
-		}
+		const matches = namespace.match( /^http[s]?:\/\/.*\/processes\/(u:[\d\w]*)\/?/);
+		return matches && matches.length > 1 ? matches[1] : namespace;
 	}
 
 	/**


### PR DESCRIPTION
Within OpenEO it is possible to share processes through UDP. This results in a shareable URL that needs to be defined in the namespace field of the processing graph. For example, below is a processing graph required to execute a service called `tps_evi` that is available in the `u:marketplace_tps` namespace.

```json
{
     "process_graph": {
            "tps_evi": {
                 "process_id": "tps_evi",
                 "namespace": "https://openeo.vito.be/openeo/1.0/processes/u:marketplace_tps/tps_evi",
                 "arguments": {},
                 "result": true
            }
      }
}
```

In the current implementation of the OpenEO JavaScript client, you can specify a namespace like `u:marketplace_tps` and get the processes. However, the resulting graph seems to be incorrect:

```json
{
     "process_graph": {
            "tps_evi": {
                 "process_id": "tps_evi",
                 "namespace": "u:marketplace_tps",
                 "arguments": {},
                 "result": true
            }
      }
}
```

The above processing graph cannot be executed by OpenEO as it is not able to find the process in the `u:marketplace_tps` namespace. 

With this fix, it is possible to define the full url (e.g. https://openeo.vito.be/openeo/1.0/processes/u:marketplace_tps/tps_evi) as the namespace to be loaded by the OpenEO JavaScript client. It uses the `normalizeNamespace` function to extract the namespace from the URL (if applicable!) in order to get all processes from the OpenEO API. 
