### PR TITLE
Improve federation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `id` field to the objects in the array returned by `listFederation` in `Capabilities`
+- New property `id` added to `FederationBackend` objects returned by `listFederation` in `Capabilities`
+- New functions `getFederationBackendById` and `getFederationBackendsByIds` in `Capabilities`
 
 ## [2.7.0] - 2025-01-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `id` field to the objects in the array returned by `listFederation` in `Capabilities`
+
 ## [2.7.0] - 2025-01-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New property `id` added to `FederationBackend` objects returned by `listFederation` in `Capabilities`
-- New functions `getFederationBackendById` and `getFederationBackendsByIds` in `Capabilities`
+- New functions `getFederationBackend` and `getFederationBackends` in `Capabilities`
 
 ## [2.7.0] - 2025-01-04
 

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -410,19 +410,19 @@ declare module OpenEO {
          */
         listFederation(): Array<FederationBackend>;
         /**
-         * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
+         * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object.
          * 
          * @param {string} backendId - The ID of a backend within the federation
-         * @returns {FederationBackend} The full details of the backend, or `null` if no backend with the given ID exists
+         * @returns {FederationBackend} The full details of the backend
          */
-        getFederationBackend(backendId: string): FederationBackend | null;
+        getFederationBackend(backendId: string): FederationBackend;
         /**
-         * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
+         * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects.
          * 
          * @param {Array<string>} backendIds - The IDs of backends within the federation
-         * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position either the full details of the backend, or `null` if no backend with the given ID exists
+         * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position the full details of the backend
          */
-        getFederationBackends(backendIds: Array<string>): Array<FederationBackend | null>;
+        getFederationBackends(backendIds: Array<string>): Array<FederationBackend>;
         /**
          * Lists all supported features.
          *

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -410,6 +410,20 @@ declare module OpenEO {
          */
         listFederation(): Array<FederationBackend>;
         /**
+         * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
+         * 
+         * @param {string} backendId The ID of a backend within the federation
+         * @returns {FederationBackend} The full details of the backend, or `undefined` if no backend with the given ID exists
+         */
+        getFederationBackendById(backendId: string): FederationBackend | undefined;
+        /**
+         * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
+         * 
+         * @param {Array<string>} backendIds The IDs of backends within the federation
+         * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position either the full details of the backend, or `undefined` if no backend with the given ID exists
+         */
+        getFederationBackendsByIds(backendIds: Array<string>): Array<FederationBackend | undefined>;
+        /**
          * Lists all supported features.
          *
          * @returns {Array.<string>} An array of supported features.

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -2958,7 +2958,7 @@ declare module OpenEO {
      */
     export type Process = object<string, any>;
     /**
-     * An array of backends in the federation.
+     * A back-end in the federation.
      */
     export type FederationBackend = {
         /**
@@ -2997,7 +2997,7 @@ declare module OpenEO {
     /**
      * An array, but enriched with additional details from an openEO API response.
      *
-     * Adds three properties: `url`, `links` and `federation:missing`.
+     * Adds two properties: `links` and `federation:missing`.
      */
     export type ResponseArray = any;
     export type ServiceType = object<string, any>;

--- a/openeo.d.ts
+++ b/openeo.d.ts
@@ -412,17 +412,17 @@ declare module OpenEO {
         /**
          * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
          * 
-         * @param {string} backendId The ID of a backend within the federation
-         * @returns {FederationBackend} The full details of the backend, or `undefined` if no backend with the given ID exists
+         * @param {string} backendId - The ID of a backend within the federation
+         * @returns {FederationBackend} The full details of the backend, or `null` if no backend with the given ID exists
          */
-        getFederationBackendById(backendId: string): FederationBackend | undefined;
+        getFederationBackend(backendId: string): FederationBackend | null;
         /**
          * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
          * 
-         * @param {Array<string>} backendIds The IDs of backends within the federation
-         * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position either the full details of the backend, or `undefined` if no backend with the given ID exists
+         * @param {Array<string>} backendIds - The IDs of backends within the federation
+         * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position either the full details of the backend, or `null` if no backend with the given ID exists
          */
-        getFederationBackendsByIds(backendIds: Array<string>): Array<FederationBackend | undefined>;
+        getFederationBackends(backendIds: Array<string>): Array<FederationBackend | null>;
         /**
          * Lists all supported features.
          *

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -210,21 +210,22 @@ class Capabilities {
 	}
 
 	/**
-	 * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
+	 * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object.
 	 * 
 	 * @param {string} backendId - The ID of a backend within the federation
-	 * @returns {FederationBackend | null} The full details of the backend, or `null` if no backend with the given ID exists
+	 * @returns {FederationBackend} The full details of the backend
 	 */
 	getFederationBackend(backendId) {
-		// Add `id` property to make it a proper FederationBackend object, but check for null case beforehand
-		return this.data.federation[backendId] ? { id: backendId, ...this.data.federation[backendId] } : null;
+		// Add `id` property to make it a proper FederationBackend object
+		// If backendId doesn't exist in this.data.federation, will contain just the `id` field (intended behaviour)
+		return { id: backendId, ...this.data.federation[backendId] }
 	}
 
 	/**
-	 * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
+	 * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects.
 	 * 
 	 * @param {Array<string>} backendIds - The IDs of backends within the federation
-	 * @returns {Array<FederationBackend | null>} An array in the same order as the input, containing for each position either the full details of the backend, or `null` if no backend with the given ID exists
+	 * @returns {Array<FederationBackend>} An array in the same order as the input, containing for each position the full details of the backend
 	 */
 	getFederationBackends(backendIds) {
 		// Let 'single case' function do the work, but pass `this` so that `this.data.federation` can be accessed in the callback context

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -210,6 +210,28 @@ class Capabilities {
 	}
 
 	/**
+	 * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
+	 * 
+	 * @param {string} backendId The ID of a backend within the federation
+	 * @returns {FederationBackend | undefined} The full details of the backend, or `undefined` if no backend with the given ID exists
+	 */
+	getFederationBackendById(backendId) {
+		// Add `id` property to make it a proper FederationBackend object, but check for undefined case beforehand
+		return this.data.federation[backendId] ? { id: backendId, ...this.data.federation[backendId] } : undefined;
+	}
+
+	/**
+	 * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
+	 * 
+	 * @param {Array<string>} backendIds The IDs of backends within the federation
+	 * @returns {Array<FederationBackend | undefined>} An array in the same order as the input, containing for each position either the full details of the backend, or `undefined` if no backend with the given ID exists
+	 */
+	getFederationBackendsByIds(backendIds) {
+		// Let 'single case' function do the work, but pass `this` so that `this.data.federation` can be accessed in the callback context
+		return backendIds.map(this.getFederationBackendById, this);
+	}
+
+	/**
 	 * Lists all supported features.
 	 * 
 	 * @returns {Array.<string>} An array of supported features.

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -202,8 +202,8 @@ class Capabilities {
 		if (Utils.isObject(this.data.federation)) {
 			// convert to array and add keys as `id` property
 			for(const [key, backend] of Object.entries(this.data.federation)) {
-				backend.id = key;
-				federation.push(backend);
+				// fresh object to avoid `id` showing up in this.data.federation
+				federation.push({ id: key, ...backend });
 			}
 		}
 		return federation;

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -198,7 +198,15 @@ class Capabilities {
 	 * @returns {Array.<FederationBackend>} Array of backends
 	 */
 	listFederation() {
-		return Array.isArray(this.data.federation) ? this.data.federation : [];
+		let federation = [];
+		if (Utils.isObject(this.data.federation)) {
+			// convert to array and add keys as `id` property
+			for(const [key, backend] of Object.entries(this.data.federation)) {
+				backend.id = key;
+				federation.push(backend);
+			}
+		}
+		return federation;
 	}
 
 	/**

--- a/src/capabilities.js
+++ b/src/capabilities.js
@@ -212,23 +212,23 @@ class Capabilities {
 	/**
 	 * Given just the string ID of a backend within the federation, returns that backend's full details as a FederationBackend object
 	 * 
-	 * @param {string} backendId The ID of a backend within the federation
-	 * @returns {FederationBackend | undefined} The full details of the backend, or `undefined` if no backend with the given ID exists
+	 * @param {string} backendId - The ID of a backend within the federation
+	 * @returns {FederationBackend | null} The full details of the backend, or `null` if no backend with the given ID exists
 	 */
-	getFederationBackendById(backendId) {
-		// Add `id` property to make it a proper FederationBackend object, but check for undefined case beforehand
-		return this.data.federation[backendId] ? { id: backendId, ...this.data.federation[backendId] } : undefined;
+	getFederationBackend(backendId) {
+		// Add `id` property to make it a proper FederationBackend object, but check for null case beforehand
+		return this.data.federation[backendId] ? { id: backendId, ...this.data.federation[backendId] } : null;
 	}
 
 	/**
 	 * Given a list of string IDs of backends within the federation, returns those backends' full details as FederationBackend objects
 	 * 
-	 * @param {Array<string>} backendIds The IDs of backends within the federation
-	 * @returns {Array<FederationBackend | undefined>} An array in the same order as the input, containing for each position either the full details of the backend, or `undefined` if no backend with the given ID exists
+	 * @param {Array<string>} backendIds - The IDs of backends within the federation
+	 * @returns {Array<FederationBackend | null>} An array in the same order as the input, containing for each position either the full details of the backend, or `null` if no backend with the given ID exists
 	 */
-	getFederationBackendsByIds(backendIds) {
+	getFederationBackends(backendIds) {
 		// Let 'single case' function do the work, but pass `this` so that `this.data.federation` can be accessed in the callback context
-		return backendIds.map(this.getFederationBackendById, this);
+		return backendIds.map(this.getFederationBackend, this);
 	}
 
 	/**

--- a/src/pages.js
+++ b/src/pages.js
@@ -21,7 +21,7 @@ class Pages {
    * @param {Connection} connection
    * @param {string} endpoint
    * @param {string} key
-   * @param {Constructor} cls
+   * @param {Constructor} cls Class
    * @param {object} [params={}]
    * @param {string} primaryKey
    */

--- a/src/pages.js
+++ b/src/pages.js
@@ -21,7 +21,7 @@ class Pages {
    * @param {Connection} connection
    * @param {string} endpoint
    * @param {string} key
-   * @param {Constructor} cls Class
+   * @param {Constructor} cls - Class
    * @param {object} [params={}]
    * @param {string} primaryKey
    */

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -196,7 +196,7 @@
  */
 
 /**
- * An array of backends in the federation.
+ * A back-end in the federation.
  * 
  * @typedef FederationBackend
  * @type {object}
@@ -204,7 +204,7 @@
  * @property {string} url URL to the versioned API endpoint of the back-end.
  * @property {string} title Name of the back-end.
  * @property {string} description A description of the back-end and its specifics.
- * @property {string} status Current status of the back-ends (online or offline).
+ * @property {string} status Current status of the back-end (online or offline).
  * @property {string} last_status_check The time at which the status of the back-end was checked last, formatted as a RFC 3339 date-time.
  * @property {string} last_successful_check If the `status` is `offline`: The time at which the back-end was checked and available the last time. Otherwise, this is equal to the property `last_status_check`. Formatted as a RFC 3339 date-time.
  * @property {boolean} experimental Declares the back-end to be experimental.
@@ -214,7 +214,7 @@
 /**
  * An array, but enriched with additional details from an openEO API response.
  * 
- * Adds three properties: `links` and `federation:missing`.
+ * Adds two properties: `links` and `federation:missing`.
  * 
  * @typedef ResponseArray
  * @augments Array

--- a/src/typedefs.js
+++ b/src/typedefs.js
@@ -200,6 +200,7 @@
  * 
  * @typedef FederationBackend
  * @type {object}
+ * @property {string} id ID of the back-end within the federation.
  * @property {string} url URL to the versioned API endpoint of the back-end.
  * @property {string} title Name of the back-end.
  * @property {string} description A description of the back-end and its specifics.


### PR DESCRIPTION
This adds `id` fields to the objects in the array returned by `listFederation` in `Capabilities`, so that the backend details can be linked to what's in `federation:backends` and `federation:missing`, which are just lists of IDs.

Also, it fixes that `listFederation` used to _always_ return the empty array, as it expected `federation` to be an array, while it's actually always an object.